### PR TITLE
fix(theme): get color mode value before page rendering

### DIFF
--- a/components/chakra.js
+++ b/components/chakra.js
@@ -1,0 +1,27 @@
+import {
+  ChakraProvider,
+  cookieStorageManager,
+  localStorageManager
+} from '@chakra-ui/react'
+import theme from '../lib/theme'
+
+export default function Chakra({ cookies, children }) {
+  const colorModeManager =
+    typeof cookies === 'string'
+      ? cookieStorageManager(cookies)
+      : localStorageManager
+
+  return (
+    <ChakraProvider theme={theme} colorModeManager={colorModeManager}>
+      {children}
+    </ChakraProvider>
+  )
+}
+
+export function getServerSideProps({ req }) {
+  return {
+    props: {
+      cookies: req.headers.cookie ?? ''
+    }
+  }
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,19 +1,18 @@
-import { ChakraProvider } from '@chakra-ui/react'
 import Layout from '../components/layouts/main'
 import Fonts from '../components/fonts'
-import theme from '../lib/theme'
 import { AnimatePresence } from 'framer-motion'
+import Chakra from '../components/chakra'
 
 function Website({ Component, pageProps, router }) {
   return (
-    <ChakraProvider theme={theme}>
+    <Chakra cookies={pageProps.cookies}>
       <Fonts />
       <Layout router={router}>
         <AnimatePresence exitBeforeEnter initial={true}>
           <Component {...pageProps} key={router.route} />
         </AnimatePresence>
       </Layout>
-    </ChakraProvider>
+    </Chakra>
   )
 }
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -208,3 +208,4 @@ const Home = () => (
 )
 
 export default Home
+export { getServerSideProps } from '../components/chakra'

--- a/pages/posts.js
+++ b/pages/posts.js
@@ -66,3 +66,4 @@ const Posts = () => (
 )
 
 export default Posts
+export { getServerSideProps } from '../components/chakra'

--- a/pages/works.js
+++ b/pages/works.js
@@ -115,3 +115,4 @@ const Works = () => (
 )
 
 export default Works
+export { getServerSideProps } from '../components/chakra'

--- a/pages/works/amembo.js
+++ b/pages/works/amembo.js
@@ -102,3 +102,4 @@ const Work = () => (
 )
 
 export default Work
+export { getServerSideProps } from '../../components/chakra'

--- a/pages/works/fourpainters.js
+++ b/pages/works/fourpainters.js
@@ -96,3 +96,4 @@ const Work = () => (
 )
 
 export default Work
+export { getServerSideProps } from '../../components/chakra'

--- a/pages/works/freedbtagger.js
+++ b/pages/works/freedbtagger.js
@@ -123,3 +123,4 @@ const Work = () => (
 )
 
 export default Work
+export { getServerSideProps } from '../../components/chakra'

--- a/pages/works/inkdrop.js
+++ b/pages/works/inkdrop.js
@@ -45,3 +45,4 @@ const Work = () => (
 )
 
 export default Work
+export { getServerSideProps } from '../../components/chakra'

--- a/pages/works/menkiki.js
+++ b/pages/works/menkiki.js
@@ -92,3 +92,4 @@ const Work = () => (
 )
 
 export default Work
+export { getServerSideProps } from '../../components/chakra'

--- a/pages/works/modetokyo.js
+++ b/pages/works/modetokyo.js
@@ -71,3 +71,4 @@ const Work = () => (
 )
 
 export default Work
+export { getServerSideProps } from '../../components/chakra'

--- a/pages/works/pichu2.js
+++ b/pages/works/pichu2.js
@@ -65,3 +65,4 @@ const Work = () => (
 )
 
 export default Work
+export { getServerSideProps } from '../../components/chakra'

--- a/pages/works/styly.js
+++ b/pages/works/styly.js
@@ -59,3 +59,4 @@ const Work = () => (
 )
 
 export default Work
+export { getServerSideProps } from '../../components/chakra'

--- a/pages/works/walknote.js
+++ b/pages/works/walknote.js
@@ -98,3 +98,4 @@ const Work = () => (
 )
 
 export default Work
+export { getServerSideProps } from '../../components/chakra'


### PR DESCRIPTION
Fixed #12 

### HOW TO TEST THIS PULL REQUEST
1. Visit both versions of the website - [production](https://www.craftz.dog/) and [preview](https://craftzdog-homepage-git-fork-k3nz11-master-craftzdog.vercel.app/).
2. Change the theme for each version of the website.
3. Refresh the page and you'll see:
     a. the production website will show the previous theme
     b. the preview website will show the updated theme