### PR TITLE
space between words

### DIFF
--- a/components/paragraph.js
+++ b/components/paragraph.js
@@ -1,7 +1,7 @@
 import styled from '@emotion/styled'
 
 const Paragraph = styled.p`
-  text-align: justify;
+  text-align: left;
   text-indent: 1em;
 `
 


### PR DESCRIPTION
the text-align justify for left
taking out the spaces between the letters called mouse paths