### PR TITLE
fix(navbar): update the background color when click item in navbar

### DIFF
--- a/components/navbar.js
+++ b/components/navbar.js
@@ -42,6 +42,24 @@ const MenuLink = forwardRef((props, ref) => (
   <Link ref={ref} as={NextLink} {...props} />
 ))
 
+const MenuItemLink = ({ href, path, children, ...props }) => {
+  const active = path === href
+  const inactiveColor = useColorModeValue('gray.800', 'whiteAlpha.900')
+  return (
+    <MenuItem
+      as={MenuLink}
+      href={href}
+      bg={active ? 'grassTeal' : 'none'}
+      color={active ? '#202023' : inactiveColor}
+      _focus={active ? {} : { bg: 'none' }}
+      _hover={active ? {} : { bg: 'none' }}
+      {...props}
+    >
+      {children}
+    </MenuItem>
+  )
+}
+
 const Navbar = props => {
   const { path } = props
 
@@ -113,21 +131,21 @@ const Navbar = props => {
                 aria-label="Options"
               />
               <MenuList>
-                <MenuItem as={MenuLink} href="/">
+                <MenuItemLink href="/" path={path}>
                   About
-                </MenuItem>
-                <MenuItem as={MenuLink} href="/works">
+                </MenuItemLink>
+                <MenuItemLink href="/works" path={path}>
                   Works
-                </MenuItem>
-                <MenuItem as={MenuLink} href="https://store.craftz.dog/">
+                </MenuItemLink>
+                <MenuItemLink href="https://store.craftz.dog/" path={path}>
                   Wallpapers
-                </MenuItem>
-                <MenuItem as={MenuLink} href="/posts">
+                </MenuItemLink>
+                <MenuItemLink href="/posts" path={path}>
                   Posts
-                </MenuItem>
-                <MenuItem as={MenuLink} href="https://uses.craftz.dog/">
+                </MenuItemLink>
+                <MenuItemLink href="https://uses.craftz.dog/" path={path}>
                   Uses
-                </MenuItem>
+                </MenuItemLink>
                 <MenuItem
                   as={Link}
                   href="https://github.com/craftzdog/craftzdog-homepage"


### PR DESCRIPTION
Currently, the bg of first element (About) is always highlighted though user choose other page.
Before fix:
<img width="473" height="927" alt="Screenshot 2026-03-04 at 20 49 25" src="https://github.com/user-attachments/assets/7f1e37af-b863-4acb-b748-c2055eb3c89e" />
After fix: 
<img width="250" height="469" alt="image" src="https://github.com/user-attachments/assets/99a6af68-c810-4557-97ec-2e1f75ef1e73" />
